### PR TITLE
motor idle (windings off) when steps done

### DIFF
--- a/drivers/misc/sample_motor/motor.c
+++ b/drivers/misc/sample_motor/motor.c
@@ -96,6 +96,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
             if(info->motor_status.x_min == 1){
                 info->set_steps[info->direction] = 0;
                 info->cur_steps[info->direction] = 0;
+                motor_idle(info);
             }
 
             if (info->cur_steps[info->direction] != info->set_steps[info->direction]) {
@@ -113,6 +114,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
             if(info->motor_status.x_max == 1){
                 info->set_steps[info->direction] = 0;
                 info->cur_steps[info->direction] = 0;
+                motor_idle(info);
             }
 
             if (info->cur_steps[info->direction] != info->set_steps[info->direction]) {
@@ -129,6 +131,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
             if(info->motor_status.y_max == 1){
                 info->set_steps[info->direction] = 0;
                 info->cur_steps[info->direction] = 0;
+                motor_idle(info);
             }
 
             if (info->cur_steps[info->direction] != info->set_steps[info->direction]) {
@@ -145,6 +148,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
             if(info->motor_status.y_min == 1){
                 info->set_steps[info->direction] = 0;
                 info->cur_steps[info->direction] = 0;
+                motor_idle(info);
             }
 
             if (info->cur_steps[info->direction] != info->set_steps[info->direction]) {

--- a/drivers/misc/sample_motor/motor.c
+++ b/drivers/misc/sample_motor/motor.c
@@ -405,15 +405,19 @@ static int motor_probe(struct platform_device *pdev) {
 
         if (info->pdata[i]->motor_st1_gpio != -1) {
             gpio_request(info->pdata[i]->motor_st1_gpio, "motor_st1_gpio");
+            gpio_direction_output(info->pdata[i]->motor_st1_gpio, 0);
         }
         if (info->pdata[i]->motor_st2_gpio != -1) {
             gpio_request(info->pdata[i]->motor_st2_gpio, "motor_st2_gpio");
+            gpio_direction_output(info->pdata[i]->motor_st2_gpio, 0);
         }
         if (info->pdata[i]->motor_st3_gpio != -1) {
             gpio_request(info->pdata[i]->motor_st3_gpio, "motor_st3_gpio");
+            gpio_direction_output(info->pdata[i]->motor_st3_gpio, 0);
         }
         if (info->pdata[i]->motor_st4_gpio != -1) {
             gpio_request(info->pdata[i]->motor_st4_gpio, "motor_st4_gpio");
+            gpio_direction_output(info->pdata[i]->motor_st4_gpio, 0);
         }
     }
 

--- a/drivers/misc/sample_motor/motor.c
+++ b/drivers/misc/sample_motor/motor.c
@@ -104,7 +104,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.x_steps--;
-                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction])
                     motor_idle(info);
             }
             break;
@@ -121,7 +121,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.x_steps++;
-                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction])
                     motor_idle(info);
             }
             break;
@@ -137,7 +137,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.y_steps++;
-                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction])
                     motor_idle(info);
             }
             break;
@@ -153,7 +153,7 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.y_steps--;
-                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction])
                     motor_idle(info);
             }
             break;

--- a/drivers/misc/sample_motor/motor.c
+++ b/drivers/misc/sample_motor/motor.c
@@ -62,6 +62,17 @@ static unsigned char step_8[8] = {
         0x09
 };
 
+static int motor_idle(struct motor_info *info) {
+    int i = info->id;
+
+    gpio_direction_output(info->pdata[i]->motor_st1_gpio, 0);
+    gpio_direction_output(info->pdata[i]->motor_st2_gpio, 0);
+    gpio_direction_output(info->pdata[i]->motor_st3_gpio, 0);
+    gpio_direction_output(info->pdata[i]->motor_st4_gpio, 0);
+
+    return 0;
+}
+
 static int motor_step(struct motor_info *info) {
     int i = info->id;
 
@@ -93,6 +104,8 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.x_steps--;
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                    motor_idle(info);
             }
             break;
         case MOTOR_DIRECTIONAL_RIGHT:
@@ -108,6 +121,8 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.x_steps++;
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                    motor_idle(info);
             }
             break;
         case MOTOR_DIRECTIONAL_UP:
@@ -122,15 +137,15 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.y_steps++;
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                    motor_idle(info);
             }
             break;
         case MOTOR_DIRECTIONAL_DOWN:
-
             if(info->motor_status.y_min == 1){
                 info->set_steps[info->direction] = 0;
                 info->cur_steps[info->direction] = 0;
             }
-
 
             if (info->cur_steps[info->direction] != info->set_steps[info->direction]) {
                 info->run_step = (sizeof(step_8) - 1) - info->cur_steps[info->direction] % sizeof(step_8);
@@ -138,6 +153,8 @@ static irqreturn_t jz_timer_interrupt(int irq, void *dev_id) {
                 motor_step(info);
                 info->cur_steps[info->direction]++;
                 info->motor_status.y_steps--;
+                if(info->cur_steps[info->direction] == info->set_steps[info->direction]
+                    motor_idle(info);
             }
             break;
         default:


### PR DESCRIPTION
Proposal fix for (hacks) issue #249
https://github.com/EliasKotlyar/Xiaomi-Dafang-Hacks/issues/249

I introduce an extra function in the motor driver, called motor_idle(), that sets all motor phases to zero

For the 4 motions, after taking a step I add a check to see if target has been reached. If it has, I call motor_idle()

I haven't set up an environment to build myself, will try to do so in coming days.
But in the mean time (and since the change is simple) I already created this PR
