### PR TITLE
Busybox: Compile flash_eraseall

### DIFF
--- a/compile_busybox.sh
+++ b/compile_busybox.sh
@@ -20,4 +20,8 @@ sed -e 's/CONFIG_FALLOCATE=y/CONFIG_FALLOCATE=n/' -i .config
 sed -e 's/CONFIG_NSENTER=y/CONFIG_NSENTER=n/' -i .config
 sed -e 's/CONFIG_FSYNC=y/CONFIG_FSYNC=n/' -i .config
 sed -e 's/CONFIG_SYNC=y/CONFIG_SYNC=n/' -i .config
+
+# Enable some features (note the /c which changes the entire line)
+sed -e '/CONFIG_FLASH_ERASEALL/c\CONFIG_FLASH_ERASEALL=y' -i .config
+
 make CROSS_COMPILE=$CROSS_COMPILE


### PR DESCRIPTION
The standard busybox config doesn't include the applet flash_eraseall,
which is needed for erasing the flash device.

This is included in the stock busybox, but not in the custom one.

Closes: EliasKotlyar/Xiaomi-Dafang-Hacks#496

Signed-off-by: Dave Walker (Daviey) <email@daviey.com>